### PR TITLE
Fix shell code injection and merging

### DIFF
--- a/diff.js
+++ b/diff.js
@@ -1,11 +1,15 @@
 #!/usr/bin/env osascript -l JavaScript
 
+function escape(str) {
+  return str.replace(/'/g, "'\\''")
+}
+
 function run(argv) {
   var app = Application.currentApplication()
   app.includeStandardAdditions = true
   app.doShellScript('mkdir -p /tmp/word_git')
-  app.doShellScript('cp "' + argv[0] + '" /tmp/word_git/doc1.docx')
-  app.doShellScript('cp "' + argv[1] + '" /tmp/word_git/doc2.docx')
+  app.doShellScript("cp '" + escape(argv[0]) + "' /tmp/word_git/doc1.docx")
+  app.doShellScript("cp '" + escape(argv[1]) + "' /tmp/word_git/doc2.docx")
   var word = Application('Microsoft Word')
   word.open('/tmp/word_git/doc2.docx', {addToRecentFiles: false})
   word.documents['doc2.docx'].close()

--- a/merge.js
+++ b/merge.js
@@ -1,5 +1,9 @@
 #!/usr/bin/env osascript -l JavaScript
 
+function escape(str) {
+  return str.replace(/'/g, "'\\''")
+}
+
 function run(argv) {
   var app = Application.currentApplication()
   app.includeStandardAdditions = true
@@ -7,9 +11,9 @@ function run(argv) {
   var word = Application('Microsoft Word')
 
   app.doShellScript('mkdir -p /tmp/word_git')
-  app.doShellScript('cp "' + argv[0] + '" /tmp/word_git/base.docx')
-  app.doShellScript('cp "' + argv[1] + '" /tmp/word_git/local.docx')
-  app.doShellScript('cp "' + argv[2] + '" /tmp/word_git/remote.docx')
+  app.doShellScript("cp '" + escape(argv[0]) + "' /tmp/word_git/base.docx")
+  app.doShellScript("cp '" + escape(argv[1]) + "' /tmp/word_git/local.docx")
+  app.doShellScript("cp '" + escape(argv[2]) + "' /tmp/word_git/remote.docx")
 
   word.open('/tmp/word_git/local.docx', {addToRecentFiles: false})
   word.documents['local.docx'].close()
@@ -37,5 +41,5 @@ function run(argv) {
   app.displayDialog('Merge your changes now.', {buttons: ["Done Merging"]})
   word.documents['merged.docx'].close({saving: "yes"})
 
-  app.doShellScript('cp /tmp/word_git/remote.docx "' + argv[3] + '"')
+  app.doShellScript("cp /tmp/word_git/remote.docx '" + escape(argv[3]) + "'")
 }

--- a/merge.js
+++ b/merge.js
@@ -41,5 +41,5 @@ function run(argv) {
   app.displayDialog('Merge your changes now.', {buttons: ["Done Merging"]})
   word.documents['merged.docx'].close({saving: "yes"})
 
-  app.doShellScript("cp /tmp/word_git/remote.docx '" + escape(argv[3]) + "'")
+  app.doShellScript("cp /tmp/word_git/merged.docx '" + escape(argv[3]) + "'")
 }


### PR DESCRIPTION
The previous code used double quotes to surround paths, which still allows environment variables and shell code to be evaluated by the shell. Hence, we use single quotes now, to avoid this problem.

PoC exploit:

```sh
#!/bin/sh -eux

POC=$(mktemp -d)
mkdir -p "$POC"
cd "$POC"
git init
git config difftool.Word.cmd '/path/to/WordGit/diff.js "$LOCAL" "$REMOTE"'

# Test case #1
touch '`touch foo`.docx'
git add ./*.docx
test ! -e foo # Will fail if file 'foo' exists (sanity check)
git difftool -t Word --cached
test ! -e foo # Will fail if file 'foo' exists. Oops.
git reset --hard

# Test case #2
touch  "'"'`touch bar`.docx'"'"
git add ./*.docx*
test ! -e bar # Will fail if file 'bar' exists (sanity check)
ls
git difftool -t Word --cached
test ! -e bar # Will fail if file 'bar' exists. Oops.
git reset --hard

# Cleanup
#rm -rf "$POC"
```

You need to change the path to WordGit. Then you can run it and test the exit code. If the exit code is 1, the exploit worked. If the exit code is 0 the exploit is fixed.